### PR TITLE
Improved Unique, Set, Rare, Magic Tiers

### DIFF
--- a/BH.cfg
+++ b/BH.cfg
@@ -371,26 +371,32 @@ ItemDisplay[CRAFT]: %NAME%%ORANGE%%CONTINUE% // need 1.9.8
 
 // Griffon's Eye
 ItemDisplay[UNI ci3]: %ORANGE%T1%MAP% %NAME%%notify-8%
-// Death's Fathom
-ItemDisplay[UNI obf]: %ORANGE%T1%MAP% %NAME%%notify-8%
+// High Death's Fathom
+ItemDisplay[UNI !ID obf]: %ORANGE%T1%MAP% %NAME%%notify-8%
+ItemDisplay[UNI ID obf STAT331>25]: %ORANGE%T1%MAP% %NAME%%notify-8%
 // Death's Web
 ItemDisplay[UNI 7gw]: %ORANGE%T1%MAP% %NAME%%notify-8%
 // 3os/unID Eth Tomb Reaver
 ItemDisplay[UNI ETH 7pa SOCK=3]: %ORANGE%T1%MAP% %NAME%%notify-8%
 ItemDisplay[UNI ETH 7pa !ID]: %ORANGE%T1%MAP% %NAME%%notify-8%
 // Eth Death Cleaver
-ItemDisplay[UNI ETH 7wa]: %ORANGE%T1%MAP% %NAME%%notify-8%
+ItemDisplay[UNI ETH 7wa ED>249]: %ORANGE%T1%MAP% %NAME%%notify-8%
+ItemDisplay[UNI ETH 7wa ED<250]: %RED%T3%MAP%{Low ED Roll} %NAME%%notify-1%%TIER-3%
 // 2os/unID Crown of Ages
 ItemDisplay[UNI urn SOCK=2]: %ORANGE%T1%MAP% %NAME%%notify-8%
 ItemDisplay[UNI urn !ID]: %ORANGE%T1%MAP% %NAME%%notify-8%
 // Tyreal's Might and potential unID SAs
 ItemDisplay[UNI uar FRW>19]: %ORANGE%T1%MAP% %NAME%%notify-8%
 ItemDisplay[UNI uar ILVL>86 !ID]: %ORANGE%T1%border-60%%dot-00% %NAME%%notify-8%
-
+ItemDisplay[UNI uar ILVL<87 !ID]: %WHITE%Not Tyrael's% %NAME%
+// 15% Nova(48) or 15% Enchant(52) Ormus
+// STAT-330=light, STAT-329=fire damage
+ItemDisplay[UNI uui ID ((SK48>0 STAT330=15) OR (SK52>0 STAT329=15))]: %ORANGE%T1%MAP% %NAME%%notify-8%
 
 // TIER 2
 // ------
-
+// Low Death's Fathom
+ItemDisplay[UNI ID obf]: %PURPLE%T2%MAP% %NAME%%notify-0b%
 // Arachnid Mesh
 ItemDisplay[UNI ulc]: %PURPLE%T2%MAP% %NAME%%notify-0b%
 // Eth Reaper's Toll
@@ -404,16 +410,24 @@ ItemDisplay[UNI uhm !ID]: %PURPLE%T2%MAP% %NAME%%notify-0b%
 ItemDisplay[UNI rin ALLSK>0]: %PURPLE%T2%MAP% %NAME%%notify-0b%
 // Mara's Kaleidoscope
 ItemDisplay[UNI amu ALLSK>1 RES>19]: %PURPLE%T2%MAP% %NAME%%notify-0b%
-// Lightning, Chain Lightning, Enchant, or Blizzard Ormus
-ItemDisplay[UNI uui (SK49>0 OR SK53>0 OR SK52>0 OR SK59>0)]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+// Lightning(49), Chain Lightning(53), Nova(48), Enchant(52), Frost Nova(44), or Blizzard(59) Ormus 
+// STAT-330 = +lightning skill damage,           329=fire,    STAT-331 = +cold skill damage
+ItemDisplay[UNI uui ID (((SK49>0 OR SK53>0) STAT330=15) OR (SK48>0 STAT330=14) OR (SK52>0 STAT329=14) OR ((SK44>0 OR SK59>0) STAT331=15)]: %PURPLE%T2%MAP% %NAME%%notify-0b%
 // +3 PNB darkforce and unID bloodlord skulls
-ItemDisplay[UNI nef TABSK17>2]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[UNI nef TABSK16=3 TABSK17=3 TABSK18=3]: %ORANGE%T1%MAP% %NAME%%notify-8%
+ItemDisplay[UNI nef TABSK17=3]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[UNI nef TABSK17=2]: %PURPLE%T4%MAP% %NAME%%notify-0b%
+ItemDisplay[UNI nef TABSK17=1]: %SAGE%T5%MAP% %NAME%%TIER-5%
 ItemDisplay[UNI nef !ID]: %PURPLE%T2%MAP% %NAME%%notify-0b%
 
 
 // TIER 3
 // ------
 
+// Ormus Robes with<15% dmg and matching skill
+// Lightning(49), Chain Lightning(53), Enchant(52), Frost Nova(44), or Blizzard(59) Ormus 
+// STAT-330 = +lightning skill damage, 329=fire,    STAT-331 = +cold skill damage
+ItemDisplay[UNI uui ID (((SK49>0 OR SK53>0) STAT330=14) OR (SK52>0 STAT329=13) OR ((SK44>0 OR SK59>0) STAT331=14)]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // Harlequin Crest
 ItemDisplay[UNI uap]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // Tal Rasha's Guardianship (armor)
@@ -423,7 +437,9 @@ ItemDisplay[SET amu CLSK1>1]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // Andariel's Visage
 ItemDisplay[UNI usk]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // War Travelers
-ItemDisplay[UNI xtb]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[UNI xtb MFIND>42]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[UNI xtb MFIND>35]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[UNI xtb]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Eth Sandstorm Trek
 ItemDisplay[UNI ETH uvb]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // Eth Vampire Gaze
@@ -434,14 +450,18 @@ ItemDisplay[UNI ETH ama]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 ItemDisplay[UNI uhg]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // Stormlash and potential unID scourges
 ItemDisplay[UNI 7fl IAS=30]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[UNI 7fl IAS=50 ED>269]: %SAGE%T5%MAP% %NAME%%TIER-5%
+ItemDisplay[UNI 7fl IAS=50 ED<270]: %GRAY%T6%MAP% Nope %NAME%%TIER-6%
 ItemDisplay[UNI 7fl ILVL>85 !ID]: %RED%T3%border-0a%%dot-00% %NAME%%notify-1%%TIER-3%
 // Wisp Projector
+ItemDisplay[UNI rin MFIND>15 STAT144>15 CHSK236=5]: %PURPLE%T2%MAP% %NAME%%notify-0b% // STAT-144 Light Absorb
 ItemDisplay[UNI rin CHSK236=5]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3% // sk236 (heart of wolv), lvl 5
 // 3os Head Hunter's Glory and unID troll nests
 ItemDisplay[UNI ush SOCK=3]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 ItemDisplay[UNI ush !ID]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // 2os Giant Skull and unID bone visage
 ItemDisplay[UNI uh9 SOCK=2]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[UNI uh9 SOCK<2]: %GRAY%T6%MAP% Nope %NAME%%TIER-6%
 ItemDisplay[UNI uh9 !ID]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // Windforce
 ItemDisplay[UNI 6lw]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
@@ -455,27 +475,49 @@ ItemDisplay[UNI 7pa !ID]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 // Mang Song's Lesson
 ItemDisplay[UNI 6ws]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 
+// Tiers for Rainbow Facets
+// https://github.com/underbent/slashdiablo-maphack/blob/41e2a08c8ba86913480ef555fb8d394ab83dee1b/BH/Constants.h#L463
+ItemDisplay[UNI jew STAT329=5]: %RED%+%GOLD%T3%MAP% -%STAT-333%/+%STAT-329% Fire %NAME%%TIER-3%
+ItemDisplay[UNI jew STAT329>0 STAT329<5]: %GOLD%+%GOLD%T4%MAP% -%STAT-333%/+%STAT-329% Fire %NAME%%TIER-4%
+ItemDisplay[UNI jew (STAT334=5 OR (STAT334=4 STAT330=5))]: %PURPLE%+%GOLD%T2%MAP% -%STAT-334%/+%STAT-330% Lightning %NAME%%notify-0b% 
+ItemDisplay[UNI jew STAT334>0 STAT334<5]: %RED%+%GOLD%T3%MAP% -%STAT-334%/+%STAT-330% Lightning %NAME%%TIER-3%
+ItemDisplay[UNI jew STAT331>0 STAT331<5]: %RED%+%GOLD%T3%MAP% -%STAT-335%/+%STAT-331% Cold %NAME%%TIER-3%
+ItemDisplay[UNI jew STAT336=5 STAT332=5]: %PURPLE%+%GOLD%T2%MAP% -%STAT-336%/+%STAT-332% Poison %NAME%%notify-0b%
+ItemDisplay[UNI jew STAT336=5 STAT332<5]: %RED%+%GOLD%T3%MAP% -%STAT-336%/+%STAT-332% Poison %NAME%%TIER-3%
+ItemDisplay[UNI jew STAT336>0 STAT336<5]: %GOLD%+%GOLD%T4%MAP% -%STAT-336%/+%STAT-332% Poison %NAME%%TIER-4%
 
 // TIER 4
 // ------
 
+// Ormus Robes with 15% dmg and random skill OR good skill but low matching skill damage
+// Lightning(49), Chain Lightning(53), Nova(48), Enchant(52), Frost Nova(44), or Blizzard(59) Ormus 
+// STAT-330 = +lightning skill damage,           329=fire,    STAT-331 = +cold skill damage
+ItemDisplay[UNI uui ID ((STAT331=15 OR STAT330=15 OR STAT329=15) OR (SK49>0 OR SK53>0 OR SK48>0 OR SK52>0 OR SK44>0 OR SK59>0))]: %GOLD%T4%MAP% %STAT-331%/%STAT-330%/%STAT-329% %NAME%%TIER-4%
+// Catch other random Ormus rolls
+ItemDisplay[UNI uui ID]:  %GRAY%T6%MAP% Nope %NAME%%TIER-6%
 // The Oculus
 ItemDisplay[UNI oba]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Ondal's Wisdom
-ItemDisplay[UNI 6cs]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[UNI !ID 6cs]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[UNI ALLSK=4 6cs]: %GOLD%T4%MAP% 4SK %NAME%%TIER-4%
+ItemDisplay[UNI ALLSK<4 6cs]: %GRAY%T6%MAP% Nope %NAME%%TIER-6%
 // Herald of Zakarum
 ItemDisplay[UNI pa9]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Titan's Revenge
 ItemDisplay[UNI ama]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Vipermagi
+ItemDisplay[UNI xea RES=35 STAT35=13]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[UNI xea STAT35>9 (RES=32 RES=33 OR RES=34)]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 ItemDisplay[UNI xea]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Gore Rider
 ItemDisplay[UNI xhb]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Aldur's Advance (boots)
+ItemDisplay[SET xtb FRES=50]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
 ItemDisplay[SET xtb]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // String of Ears
 ItemDisplay[UNI zlb]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Ravenfrost
+ItemDisplay[UNI rin AR=250 DEX=20]: %PURPLE%T2%MAP% %NAME%%notify-0b%
 ItemDisplay[UNI rin AR>149]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Highlord's Wrath
 ItemDisplay[UNI amu ALLSK>0 IAS=20]: %GOLD%T4%MAP% %NAME%%TIER-4%
@@ -521,6 +563,7 @@ ItemDisplay[UNI amu AR>399]: %GOLD%T4%MAP% %NAME%%TIER-4%
 ItemDisplay[UNI ETH 7sr]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Eth Guardian Angel
 ItemDisplay[UNI ETH xlt]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[UNI !ETH  ED>194 xlt]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Eth Shaftstop
 ItemDisplay[UNI ETH xhn]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // 5os Eth Runemaster and potential unID ettin axes
@@ -549,8 +592,9 @@ ItemDisplay[UNI upl ALLSK=2]: %GOLD%T4%MAP% %NAME%%TIER-4%
 ItemDisplay[UNI upl !ID]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // +3 Eschuta's Temper and potential unID eldritch orbs
 ItemDisplay[UNI obc CLSK1=3]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[UNI obc ID CLSK1<3]: %GRAY%T6%MAP% Nope %NAME%%TIER-6%
 ItemDisplay[UNI obc !ID]: %GOLD%T4%MAP% %NAME%%TIER-4%
-// Sandstorm Trek
+// Sandstorm Trek (non-Eth)
 ItemDisplay[UNI uvb]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Eth Bonehew
 ItemDisplay[UNI ETH 7o7]: %GOLD%T4%MAP% %NAME%%TIER-4%
@@ -568,9 +612,18 @@ ItemDisplay[UNI xmb]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Tal Rasha's Horadric Crest (mask)
 ItemDisplay[SET xsk]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Tal Rasha's Lidless Eye (orb)
-ItemDisplay[SET oba]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[SET oba SK65>1 SK63>1 SK61>1]: %GOLD%T4%MAP% 2/2/2 %NAME%%TIER-4%
+ItemDisplay[SET oba SK65=1 SK63>1 SK61>1]: %SAGE%T5%MAP% 1/2/2 %NAME%%TIER-5%
+ItemDisplay[SET oba SK65=1 SK63=1 SK61>1]: %SAGE%T5%MAP% 1/1/2 %NAME%%TIER-5%
+ItemDisplay[SET oba SK65=1 SK63>1 SK61=1]: %SAGE%T5%MAP% 1/2/1 %NAME%%TIER-5%
+ItemDisplay[SET oba SK65>1 SK63=1 SK61>1]: %SAGE%T5%MAP% 2/1/2 %NAME%%TIER-5%
+ItemDisplay[SET oba SK65>1 SK63=1 SK61=1]: %SAGE%T5%MAP% 2/1/1 %NAME%%TIER-5%
+ItemDisplay[SET oba SK65>1 SK63>1 SK61=1]: %SAGE%T5%MAP% 2/2/1 %NAME%%TIER-5%
+ItemDisplay[SET oba SK65=1 SK63=1 SK61=1]: %SAGE%T5%MAP% 1/1/1 %NAME%%TIER-5%
+ItemDisplay[SET oba]: %SAGE%T5%MAP% %NAME%%TIER-5%
 // Tal Rasha's Fine Spun Cloth (belt)
-ItemDisplay[SET zmb]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[SET zmb MFIND=15]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[SET zmb]: %SAGE%T5%MAP% %NAME%%TIER-5%
 // Valkyrie Wing
 ItemDisplay[UNI xhm]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Razortail
@@ -579,6 +632,8 @@ ItemDisplay[UNI zvb]: %GOLD%T4%MAP% %NAME%%TIER-4%
 ItemDisplay[UNI amu IAS=20 FRW=30]: %GOLD%T4%MAP% %NAME%%TIER-4%
 // Skullder's Ire
 ItemDisplay[UNI xpl]: %GOLD%T4%MAP% %NAME%%TIER-4%
+// Eth Demon Limb
+ItemDisplay[UNI ETH 7sp]: %GOLD%T4%MAP% %NAME%%TIER-4%
 
 // TIER 5
 // ------
@@ -615,6 +670,7 @@ ItemDisplay[UNI 9tr]: %SAGE%T5%MAP% %NAME%%TIER-5%
 ItemDisplay[UNI 7kr]: %SAGE%T5%MAP% %NAME%%TIER-5%
 // 2os Heaven's Light and unID mighty scepters
 ItemDisplay[UNI 7sc SOCK=2]: %SAGE%T5%MAP% %NAME%%TIER-5%
+ItemDisplay[UNI 7sc SOCK<2]: %GRAY%T6%MAP% Nope %NAME%%TIER-6%
 ItemDisplay[UNI 7sc !ID]: %SAGE%T5%MAP% %NAME%%TIER-5%
 // Goldwrap
 ItemDisplay[UNI tbl]: %SAGE%T5%MAP% %NAME%%TIER-5%
@@ -662,14 +718,16 @@ ItemDisplay[SET urn]: %SAGE%T5%MAP% %NAME%%TIER-5%
 ItemDisplay[SET paf]: %SAGE%T5%MAP% %NAME%%TIER-5%
 // Eth Headstriker
 ItemDisplay[UNI ETH 9bs]: %SAGE%T5%MAP% %NAME%%TIER-5%
-// Guardian Angel
-ItemDisplay[UNI xlt]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// Non-Eth Low ED Guardian Angel
+ItemDisplay[UNI !ETH xlt]: %SAGE%T5%MAP% %NAME%%TIER-5%
+// Demon Limb
+ItemDisplay[UNI !ETH 7sp]: %SAGE%T5%MAP% %NAME%%TIER-5%
 // Frostburn
 ItemDisplay[UNI hgl]: %SAGE%T5%MAP% %NAME%%TIER-5%
 
 // This line pings all TC87 uniques/sets. The good ones are already added elsewhere,
 // but some people like to see pings for rare trophy items.
-ItemDisplay[(UNI OR SET) QLVL>84]: %SAGE%T5%MAP% %NAME%%TIER-5%
+ItemDisplay[(UNI OR SET) QLVL>84]: %SAGE%T5%MAP% Neat QL85+ %NAME%%TIER-5%
 
 // TIER 6
 // ------
@@ -702,6 +760,7 @@ ItemDisplay[UNI jew !ID]: %RED%+%GOLD%T3%MAP% %NAME%%TIER-3%
 ItemDisplay[UNI amu ILVL>79 !ID]: %PURPLE%+%GOLD%T3%MAP% %NAME%%TIER-3%
 // Other Uniques
 ItemDisplay[UNI amu !ID]: %GREEN%+%GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[UNI amu]: %GRAY%T6%MAP% %NAME%
 // Potential Tal Rasha's Adjudication (amulet)
 ItemDisplay[SET amu ILVL>25 !ID]: %RED%+%GREEN%T3%MAP% %NAME%%TIER-3%
 
@@ -1323,8 +1382,12 @@ ItemDisplay[CIRC !ETH MAG !ID]: %GREEN%+%BLUE%T4%MAP% %NAME%%notify-3%%TIER-4%
 // Small charms, grand charms and jewels
 ItemDisplay[!ID MAG (cm1 OR cm3 OR jew)]: %GREEN%+%BLUE%T4%MAP% %NAME%%notify-3%%TIER-4%
 
-// Monarchs (for JMoD)
+// Monarchs (for JMoD/JMoB)
 ItemDisplay[uit !ETH MAG !ID]: %GREEN%+%BLUE%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[uit MAG SOCK=4 STAT102=30]: %ORANGE%T1%MAP% JMoD %NAME%%notify-8%
+ItemDisplay[uit MAG SOCK=4 STAT102=15]: %ORANGE%T1%MAP% JMoB %NAME%%notify-8%
+ItemDisplay[uit MAG SOCK=4]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[uit MAG !ETH MAG SOCK=0 ID]: %WHITE% Nope %NAME%%TIER-6%
 
 // TIER 5
 // ------
@@ -1394,9 +1457,35 @@ ItemDisplay[RARE !ID (rin OR amu OR jew OR CIRC)]: %GREEN%+%YELLOW%T4%MAP% %NAME
 
 // Boots
 ItemDisplay[RARE !ID BOOTS]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+ItemDisplay[RARE ETH REPAIR=0 BOOTS]: %WHITE%Nope %NAME%%CONTINUE%
+ItemDisplay[RARE BOOTS FRW>10 MFIND>19 FHR>0 FRES>29 LRES>29 FRES+CRES+LRES>49]: %ORANGE%T1%MAP% %NAME%%notify-8%
+ItemDisplay[RARE BOOTS FRW>20 MFIND>10 FHR>0 FRES>25 LRES>25]: %ORANGE%T1%MAP% %NAME%%notify-8%
+ItemDisplay[RARE BOOTS FRW>10 MFIND>10 FHR>0 FRES>15 LRES>15]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[RARE BOOTS FRW>10 (MFIND>10 OR FHR>0) FRES+LRES>29]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[RARE BOOTS FRW>10 MFIND>10 (FRES>29 OR LRES>29) FRES+LRES+CRES>69]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[RARE BOOTS MFIND+FRW+FHR>30 FRES+LRES>19 FRES+LRES+CRES+PRES>59]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[RARE BOOTS MFIND+FRW+FHR>10 FRES+LRES>9 FRES+LRES+CRES+PRES>29]: %GOLD%T4%MAP% %NAME%%TIER-4%
+ItemDisplay[RARE BOOTS FRW>20 (MFIND>10 OR FHR>0) (FRES>29 OR LRES>29) MANA>29]: %RED%T3%MAP% %NAME%%notify-1%%TIER-3%
+ItemDisplay[RARE BOOTS FRW>10 MFIND>19 FHR>0 FRES>29 FRES+CRES+LRES>29]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[RARE BOOTS FRW>20 FRES>29 LRES>29 CRES>29]: %ORANGE%T1%MAP% %NAME%%notify-8%
+ItemDisplay[RARE BOOTS FRW>10 FRES>22 LRES>22 (CRES>22 OR PRES>29) FRES+CRES+LRES+PRES>59]: %PURPLE%T2%MAP% %NAME%%notify-0b%
+ItemDisplay[RARE BOOTS FRW<20 GFIND<71 MF<20 FRES+LRES+CRES<60]: %WHITE%Nope %NAME%
+ItemDisplay[RARE BOOTS GFIND<78 MF<35 FRES+LRES+CRES<60]: %WHITE%Nope %NAME%
+ItemDisplay[(MAG OR RARE) BOOTS ((GFIND>74 FRES>10) OR GFIND>78)]: %RED%T3%MAP% %STAT-79%GF %NAME%%notify-1%%TIER-3%
+ItemDisplay[(MAG OR RARE) BOOTS GFIND>74]: %GOLD%T4%MAP% %STAT-79%GF %NAME%%TIER-4%
+ItemDisplay[(MAG OR RARE) BOOTS GFIND>70 FRES>0]: %SAGE%+%BLUE%T5%MAP% %STAT-79%GF %NAME%%TIER-5%
 
 // Gloves
 ItemDisplay[RARE !ID GLOVES]: %GREEN%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+ItemDisplay[RARE ID GLOVES (!ETH OR (ETH REPAIR)) TABSK2>1 IAS>19 (FRES>19 OR LRES>19) (MFIND>9 OR STR>4 OR DEX>4)]: %RED%T3%MAP% 2/20 %NAME%%notify-1%%TIER-3%
+ItemDisplay[RARE ID GLOVES (!ETH OR (ETH REPAIR)) (TABSK2>1 OR TABSK50>1 OR TABSK0>1)  IAS>19 (FRES>9 OR MFIND>0 OR STR>0 OR DEX>0)]: %GOLD%T4%MAP% 2/20 %NAME%%TIER-4%
+ItemDisplay[RARE GLOVES ((ETH !REPAIR) OR (TABSK0=0 TABSK2=0 TABSK50=0))]: %WHITE%Nope %NAME%
+ItemDisplay[RARE GLOVES IAS+STR+DEX+LIFE+MFIND+FRES+LRES<60]: %WHITE%Nope %NAME%
+
+// Belts
+ItemDisplay[RARE ID BELT GFIND=80 (!ETH OR (ETH REPAIR)) (FRES>0 OR !(RES=0) OR STR+LIFE>0)]: %GOLD%T4%MAP%%YELLOW% GFIND %NAME%%TIER-4%
+ItemDisplay[RARE ID BELT GFIND>74 (!ETH OR (ETH REPAIR)) (FRES>0 OR !(RES=0) OR STR+LIFE>0)]: %GREEN%+%YELLOW%T5%MAP% GFIND %NAME%%TIER-5%
+ItemDisplay[RARE ID BELT GFIND<75 RES=0 STR+LIFE=0]: %WHITE%Nope %NAME%
 
 // Whitelist only
 // --------------
@@ -1411,10 +1500,20 @@ ItemDisplay[RARE DRU !ID]: %WHITE%+ %NAME%
 ItemDisplay[SIN ETH RARE !ID]: %WHITE%+ %NAME%
 
 // Rare eth weapons capable of cruel + master's (alvl 55+)
-ItemDisplay[RARE ETH !ID WEAPON !WAND !SORC ALVL>55]: %NAME%
+// Master's = +151-250 to Attack Rating, Damage: +101-150%	
+// Cruel = +201-300% Damage	
+ItemDisplay[RARE ETH !ID WEAPON !WAND !SOR ALVL>55]: %NAME%
+ItemDisplay[RARE ETH ID WEAPON !WAND !SOR ALVL>55 AR>150 ED>200]: %GOLD%T4%MAP%Cruel+Master's%NAME%%TIER-4%	
+ItemDisplay[RARE ETH ID WEAPON !WAND !SOR ALVL>55 AR>150]: %SAGE%+%YELLOW%T5%MAP%Master's%NAME%%TIER-5%
+ItemDisplay[RARE ETH ID WEAPON !WAND !SOR ALVL>55 ED>200]: %SAGE%+%YELLOW%T5%MAP%Cruel%NAME%%TIER-5%	
+ItemDisplay[RARE ETH ID WEAPON !WAND !SOR ALVL>55 AR<150 ED<200]: %WHITE%Nope %NAME%	
 
 // Rare eth armor capable of 200 ED (Godly, alvl 50+)
+// Godly = +101-200% Defense
 ItemDisplay[RARE ETH !ID CHEST ALVL>49]: %NAME%
+ItemDisplay[RARE ETH ID CHEST ALVL>49 ED>100]: %SAGE%+%YELLOW%T5%MAP% %NAME%%TIER-5%
+ItemDisplay[RARE ETH ID CHEST ALVL>49 ED<101]: %WHITE%Nope%NAME%
+
 
 // Sorc Orbs (for +5 orbs)
 ItemDisplay[SORC RARE !ID]: %WHITE%+ %NAME%


### PR DESCRIPTION
Adds Unique Tiers for:
-Ormus Robes skill rolls
-Rainbow Facet rolls
-Death's Fathom rolls
-Death Cleaver ED rolls
-Darkforce rolls
-War Trav MF rolls
-Stormlash ED rolls
-Wisp MF/Absorb rolls
-Giant Skull rolls
-Ondal's Wisdom rolls
-Vipermagi RES/MDR rolls
-Aldur's FRES roll
-Ravenfrost AR/DEX rolls
-Guardian Angel rolls
-Eschuta's Temper rolls
-Sandstorm Trek rolls
-Tal Orb rolls (with stat tags)
-Tal Belt MFIND roll
-Demon Limb rolls
-Heaven's Light socket rolls
-Improved JMOD/JMOB Tiers/tags
-Rare Boot Tiers
-Rare Glove Tiers
-Rare Belt Tiers
-Improved Cruel, Master's, Godly Tiers and Tags